### PR TITLE
Improve py/client-ticking/README.md.

### DIFF
--- a/py/client-ticking/README.md
+++ b/py/client-ticking/README.md
@@ -11,22 +11,21 @@ are working on unifying these two libraries.
 
 ## Prerequisites
 
-# *CRISTIAN*: need python3 installed and specifically the package python3-dev ???
-
-
 Clone the Deephaven Core repository. For the remainder of this document we will assume that your
 clone is at the location specified by `${DHROOT}`.
-
-First, you will need to build the Deephaven C++ library and its prerequisites. To do this, see
-the file `${DHROOT}/cpp-client/README.md` in the Deephaven Core github repository.
-
-For the purpose of this document we assume that you have successfully built the library and its prerequsites in a location specified by `${DHLIB}`. On my computer `${DHLIB}` is
-`home/cfs/dhcpp/local`.
 
 ## Making the Python venv
 
 To build the code in this directory, you need a python environment with cython and numpy.
-For instance, in Ubuntu 22.04 I created a python venv and added cython and numpy to it like so:
+In Ubuntu 22.04, the packages `python3`, `python3-dev` and `python3-venv` are required.
+The can be installed with
+
+```
+sudo apt update
+sudo apt -y install python3 python3-dev python3-venv
+```
+
+The necessary python venv can be created like so:
 
 ```
 mkdir ~/py
@@ -41,19 +40,31 @@ pip3 install numpy
 pip3 install cython
 ```
 
+## Building the Deephaven C++ client
+
+The Depehaven python ticking client is built as wrapping of the Deephaven C++ client library
+using cython.  We need to build the Deephaven C++ library and its dependencies. To do this, see
+the file `${DHROOT}/cpp-client/README.md` in the Deephaven Core github repository.
+Note the restrictions on supported platforms mentioned there will for the python ticking client.
+The instructions will ask you to select a location for the installation of the C++ client library
+and its dependencies.  For the purpose of this document we assume that location is specified in
+the `${DHCPP}` environment variable.  On my computer `${DHCPP}` is `$HOME/dhcpp` (where
+`$HOME` points to my home directory).
+
 ## Building the Deephaven shared library for Python
 
 First, enter the Python client directory:
 
 ```
-cd ${DHROOT}/py/client2
+cd ${DHROOT}/py/client-ticking
 ```
 
 Then run these commands to build the Deephaven shared library:
 
 ```
-export DEEPHAVEN_LOCAL=/usr/local/dhcpp-230313/local # Or where your build of the deephaven C++ client is installed.
-rm -rf build *.so && CFLAGS="-I${DEEPHAVEN_LOCAL}/deephaven/include" LDFLAGS="-L${DEEPHAVEN_LOCAL}/deephaven/lib" python setup.py build_ext -i
+# Ensure the DHCPP environment variable is set per the instructions above
+rm -rf build  # Ensure we clean the remnants of any pre-existing build.
+CFLAGS="-I${DHCPP}/local/deephaven/include" LDFLAGS="-L${DHCPP}/local/deephaven/lib" python setup.py build_ext -i
 ```
 
 Once built, a shared object with the binary python module should show up, named like
@@ -63,7 +74,7 @@ Once built, a shared object with the binary python module should show up, named 
 
 Run python from the venv while in this directory, and try this sample Python program:
 ```
-import deephaven_client as dh
+import pydeephaven_ticking as dh
 client = dh.Client.connect("localhost:10000")
 manager = client.get_manager()
 handle = manager.empty_table(10).update(["II= ii"])


### PR DESCRIPTION
I went through the instructions and did some cleanup/changes as I did.

It did work for me:
```
cfs@coipo 21:13:26 ~/dh/oss3/deephaven-core/py/client-ticking
$ rm -rf build *.so && CFLAGS="-I${DHCPP}/local/deephaven/include" LDFLAGS="-L${DHCPP}/local/deephaven/lib" python3 setup.py build_ext -i
Compiling src/pydeephaven_ticking/_core.pyx because it changed.
[1/1] Cythonizing src/pydeephaven_ticking/_core.pyx
running build_ext
building 'pydeephaven_ticking._core' extension
creating build
creating build/temp.linux-x86_64-3.10
creating build/temp.linux-x86_64-3.10/src
creating build/temp.linux-x86_64-3.10/src/pydeephaven_ticking
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -I/home/cfs/dh/dhcpp/local/deephaven/include -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/home/cfs/py/cython2/include -I/usr/include/python3.10 -c src/pydeephaven_ticking/_core.cpp -o build/temp.linux-x86_64-3.10/src/pydeephaven_ticking/_core.o -std=c++17
creating build/lib.linux-x86_64-3.10
creating build/lib.linux-x86_64-3.10/pydeephaven_ticking
x86_64-linux-gnu-g++ -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 -L/home/cfs/dh/dhcpp/local/deephaven/lib -I/home/cfs/dh/dhcpp/local/deephaven/include -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.10/src/pydeephaven_ticking/_core.o -ldhcore -o build/lib.linux-x86_64-3.10/pydeephaven_ticking/_core.cpython-310-x86_64-linux-gnu.so
copying build/lib.linux-x86_64-3.10/pydeephaven_ticking/_core.cpython-310-x86_64-linux-gnu.so -> src/pydeephaven_ticking
(cython2)
```